### PR TITLE
timelimit can now be unset and add sasl_nocanon parameter

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -49,7 +49,12 @@
 #   Maximum number of entries to return by default.
 #
 # [*timelimit*]
-#   Maximum number of seconds to wait for answers by default.
+#   Maximum number of seconds to wait for answers by default. Set to '' (empty
+#   string) to remove this parameter from config file.
+#
+# [*sasl_nocanon*]
+#   If set to true, do not perform reverse DNS lookups to canonicalize SASL host
+#   names.
 #
 # === Examples
 #
@@ -79,6 +84,7 @@ class ldap::client (
   $net_ldap_package_provider   = $ldap::params::net_ldap_package_provider,
   $sizelimit        = $ldap::params::client_sizelimit,
   $timelimit        = $ldap::params::client_timelimit,
+  $sasl_nocanon     = $ldap::params::client_sasl_nocanon,
 ) inherits ldap::params {
 
   include stdlib

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -3,7 +3,8 @@
 # Manage the configuration of the ldap client
 #
 class ldap::client::config inherits ldap::client {
-  file { $ldap::client::config_file:
+  file { 'ldap.conf':
+    path    => $ldap::client::config_file,
     owner   => 0,
     group   => 0,
     mode    => '0644',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,8 @@ class ldap::params {
 
   $client_sizelimit = undef
   $client_timelimit = 15
+  $client_sasl_nocanon = false
+
 
   $server_package_ensure      = 'present'
   $server_service_enable      = true

--- a/spec/classes/ldap_client_spec.rb
+++ b/spec/classes/ldap_client_spec.rb
@@ -28,6 +28,39 @@ describe 'ldap::client' do
           else
               it { is_expected.not_to contain_package('net-ldap').with_ensure('present') }
           end
+          it do
+            is_expected.to contain_file('ldap.conf')
+              .with_content(/^TIMELIMIT\s+15$/)
+          end
+        end
+        context 'ldap::client class with specific parameters' do
+          let(:params) do
+            {
+              :uri          => 'ldap://localhost',
+              :base         => 'dc=example,dc=com',
+              :timelimit    => '',
+              :sasl_nocanon => true
+            }
+          end
+          # NOTE: this behaviour is directly related to PUP-5295
+          it 'should contain TIMELIMIT directive set to 15 if undef' do
+            params[:timelimit] = :undef
+            is_expected.to contain_file('ldap.conf')
+              .with_content(/^TIMELIMIT\s+15$/)
+          end
+          it 'should not contain TIMELIMIT directive if empty' do
+            is_expected.to contain_file('ldap.conf')
+              .without_content(/^TIMELIMIT\s+/)
+          end
+          it 'should contain SASL_NOCANON directive if set to true' do
+            is_expected.to contain_file('ldap.conf')
+              .with_content(/^SASL_NOCANON\s+on$/)
+          end
+          it 'should not contain SASL_NOCANON directive if set to false' do
+            params[:sasl_nocanon] = false
+            is_expected.to contain_file('ldap.conf')
+              .without_content(/^SASL_NOCANON\s+$/)
+          end
         end
       end
     end

--- a/templates/ldap.conf.erb
+++ b/templates/ldap.conf.erb
@@ -6,9 +6,12 @@ URI  <%= @uri %>
 <%- if @sizelimit -%>
 SIZELIMIT <%= @sizelimit %>
 <% end -%>
-<%- if @timelimit -%>
+<%- if @timelimit and @timelimit != '' -%>
 TIMELIMIT <%= @timelimit %>
 <% end -%>
+<%- if @sasl_nocanon -%>
+SASL_NOCANON on
+<%- end -%>
 
 <%- if @ssl == true -%>
 # SSL


### PR DESCRIPTION
- Allow `$ldap::client::timelimit` to be set to '' (empty string) so that
  `timelimit` parameter is absent from generated ldap client config file
- Add new param `$ldap::client::sasl_nocanon` which defaults to `false`
  and that not appear in ldap client config file by default.
- Add related spec tests :)