### PR TITLE
Add bindpw binddn and fix manage_package_dependencies

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -67,8 +67,8 @@
 class ldap::client (
   $uri,
   $base,
-  $binddn           = $ldap::params::binddn,
-  $bindpw           = $ldap::params::bindpw,
+  $binddn           = $ldap::params::client_binddn,
+  $bindpw           = $ldap::params::client_bindpw,
   $ssl              = $ldap::params::client_ssl,
   $ssl_cacertdir    = $ldap::params::client_ssl_cacertdir,
   $ssl_cacert       = $ldap::params::client_ssl_cacert,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -10,6 +10,12 @@
 # [*base*]
 #   The domain for which the LDAP server provides information for.
 #
+# [*binddn*]
+#   Bind to a specific username instead of using an anonymous connection 
+#
+# [*bindpw*]
+#   Bind to the specific username with this password
+#
 # [*ssl*]
 #   Whether the client should attempt to connect over SSL (false, true).
 #
@@ -61,6 +67,8 @@
 class ldap::client (
   $uri,
   $base,
+  $binddn           = $ldap::params::binddn,
+  $bindpw           = $ldap::params::bindpw,
   $ssl              = $ldap::params::client_ssl,
   $ssl_cacertdir    = $ldap::params::client_ssl_cacertdir,
   $ssl_cacert       = $ldap::params::client_ssl_cacert,

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -8,36 +8,21 @@ class ldap::client::install inherits ldap::client {
     name   => $ldap::client::package_name,
   }
 
-
-  case $::osfamily {
-    'FreeBSD': {
-      if $ldap::client::manage_package_dependencies {
-        package { 'net-ldap':
+  if $ldap::client::manage_package_dependencies {
+    if versioncmp($::puppetversion, '4.0.0') < 0 {
+       package { 'net-ldap':
           ensure   => $ldap::client::net_ldap_package_ensure,
           name     => $ldap::client::net_ldap_package_name,
           provider => $ldap::client::net_ldap_package_provider,
-        }
-      }
-    }
-    default: {
-      if versioncmp($::puppetversion, '4.0.0') > 0 {
-
-        # Puppet 4 has its own self-contained ruby environment so install the
-        # requisite packages there
-        if $ldap::client::manage_package_dependencies {
+       }
+     } else {
+       if $::osfamily != 'FreeBSD'{
+          # Puppet 4 has its own self-contained ruby environment so install the
+          # requisite packages there
           exec { '/opt/puppetlabs/puppet/bin/gem install net-ldap':
             unless => '/opt/puppetlabs/puppet/bin/gem list | grep net-ldap',
           }
-        }
-      } else {
-        if $ldap::client::manage_package_dependencies {
-          package { 'net-ldap':
-            ensure   => $ldap::client::net_ldap_package_ensure,
-            name     => $ldap::client::net_ldap_package_name,
-            provider => $ldap::client::net_ldap_package_provider,
-          }
-        }
-      }
-    }
+       }
+     }
   }
 }

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -24,15 +24,18 @@ class ldap::client::install inherits ldap::client {
 
         # Puppet 4 has its own self-contained ruby environment so install the
         # requisite packages there
-        exec { '/opt/puppetlabs/puppet/bin/gem install net-ldap':
-          unless => '/opt/puppetlabs/puppet/bin/gem list | grep net-ldap',
+        if $ldap::client::manage_package_dependencies {
+          exec { '/opt/puppetlabs/puppet/bin/gem install net-ldap':
+            unless => '/opt/puppetlabs/puppet/bin/gem list | grep net-ldap',
+          }
         }
-
       } else {
-        package { 'net-ldap':
-          ensure   => $ldap::client::net_ldap_package_ensure,
-          name     => $ldap::client::net_ldap_package_name,
-          provider => $ldap::client::net_ldap_package_provider,
+        if $ldap::client::manage_package_dependencies {
+          package { 'net-ldap':
+            ensure   => $ldap::client::net_ldap_package_ensure,
+            name     => $ldap::client::net_ldap_package_name,
+            provider => $ldap::client::net_ldap_package_provider,
+          }
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,7 +147,7 @@ class ldap::params {
       $server_directory          = '/var/openldap-data'
       $server_directory_mode     = '0700'
       $net_ldap_package_name     = 'rubygem-net-ldap'
-      $net_ldap_package_provider = 'pkgng'
+      $net_ldap_package_provider = 'gem'
     }
     'OpenBSD': {
       $ldap_config_directory     = '/etc/openldap'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,9 @@ class ldap::params {
 
   $client_package_ensure   = 'present'
   $client_config_template  = 'ldap/ldap.conf.erb'
+  
+  $client_binddn = undef
+  $client_bindpw = undef
 
   $client_ssl             = false
   $client_ssl_cacert      = undef

--- a/spec/acceptance/client_spec.rb
+++ b/spec/acceptance/client_spec.rb
@@ -21,4 +21,22 @@ describe 'ldap::client class' do
     end
   end
 
+  context 'optional parameters' do
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+        class { 'ldap::client':
+          uri  => 'ldap://localhost',
+          base => 'dc=example,dc=com',
+          binddn => 'dc=example,dc=com',
+          bindpw => 'dc=example,dc=com',
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+  end
+
+
 end

--- a/templates/ldap.conf.erb
+++ b/templates/ldap.conf.erb
@@ -2,10 +2,10 @@
 BASE <%= @base %>
 URI  <%= @uri %>
 
-<%- if @bindn == true -%>
+<%- if @bindn -%>
 BINDDN <%= @binddn %>
 <% end %>
-<%- if @binpw == true -%>
+<%- if @binpw -%>
 BINDPW <%= @bindpw %>
 <% end %>
 

--- a/templates/ldap.conf.erb
+++ b/templates/ldap.conf.erb
@@ -2,6 +2,13 @@
 BASE <%= @base %>
 URI  <%= @uri %>
 
+<%- if @bindn == true -%>
+BINDDN <%= @binddn %>
+<% end %>
+<%- if @binpw == true -%>
+BINDPW <%= @bindpw %>
+<% end %>
+
 # Timeout options
 <%- if @sizelimit -%>
 SIZELIMIT <%= @sizelimit %>

--- a/templates/ldap.conf.erb
+++ b/templates/ldap.conf.erb
@@ -2,10 +2,10 @@
 BASE <%= @base %>
 URI  <%= @uri %>
 
-<%- if @bindn -%>
+<%- if @binddn -%>
 BINDDN <%= @binddn %>
 <% end %>
-<%- if @binpw -%>
+<%- if @bindpw -%>
 BINDPW <%= @bindpw %>
 <% end %>
 


### PR DESCRIPTION
Hi,

This is 2 clustered patches: first one is to add binddn bindpw as arguments to client::ldap and the second one is to apply the manage_package_dependencies . Currently the argument only works on FreeBSD, but the client module doesn't work on debian as gem is not installed there.

I can split the patches or cleanup the second one, but they're just simple upgrade of the module.

G